### PR TITLE
HHH-12893 Allow specifying command line arguments for XJC task

### DIFF
--- a/src/main/groovy/org/hibernate/build/gradle/xjc/XjcPlugin.groovy
+++ b/src/main/groovy/org/hibernate/build/gradle/xjc/XjcPlugin.groovy
@@ -62,6 +62,7 @@ class XjcPlugin implements Plugin<Project> {
 										schema: descriptor.xsd,
 										target: descriptor.jaxbVersion,
 										extension: 'true') {
+									arg line: "-npa "
 									if ( !descriptor.xjcExtensions.empty ) {
 										arg line: descriptor.xjcExtensions.collect { "-X${it}" }.join( " " )
 									}


### PR DESCRIPTION
This PR is to introduce a new `args` option that allows the task definition to supply additional command line arguments to the XJC process.  